### PR TITLE
bug: fix accuracy metric and add `test_with_y=True`

### DIFF
--- a/Finetune_GLUE.ipynb
+++ b/Finetune_GLUE.ipynb
@@ -187,10 +187,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "accuracy_metric = AvgMetric(lambda inp,targ: torch.eq(torch.tensor(inp.argmax(dim=-1)), torch.tensor(targ)).float().mean())\n",
     "METRICS = {\n",
     "  **{ task:[MatthewsCorrCoef()] for task in ['cola']},\n",
-    "  **{ task:[accuracy] for task in ['sst2', 'mnli', 'qnli', 'rte', 'wnli', 'snli','ax']},\n",
-    "  **{ task:[F1Score(), accuracy] for task in ['mrpc', 'qqp']}, \n",
+    "  **{ task:[accuracy_metric] for task in ['sst2', 'mnli', 'qnli', 'rte', 'wnli', 'snli','ax']},\n",
+    "  **{ task:[F1Score(), accuracy_metric] for task in ['mrpc', 'qqp']}, \n",
     "  **{ task:[PearsonCorrCoef(), SpearmanCorrCoef()] for task in ['stsb']}\n",
     "}\n",
     "NUM_CLASS = {\n",
@@ -319,7 +320,7 @@
     "    glue_dsets[task]['train'] = datasets.concatenate_datasets([glue_dsets[task]['train'], swapped_train])\n",
     "\n",
     "  # Load / Make dataloaders\n",
-    "  hf_dsets = HF_Datasets(glue_dsets[task], hf_toker=hf_tokenizer, n_inp=3,\n",
+    "  hf_dsets = HF_Datasets(glue_dsets[task], hf_toker=hf_tokenizer, n_inp=3, test_with_y=True,\n",
     "                cols={'inp_ids':TensorText, 'attn_mask':noop, 'token_type_ids':noop, 'label':TensorCategory})\n",
     "  if c.double_unordered and task in ['mrpc', 'stsb']:\n",
     "    dl_kwargs = {'train': {'cache_name': f\"double_dl_{c.max_length}_train.json\"}}\n",
@@ -342,7 +343,7 @@
     "  glue_dsets['wnli'] = wsc.my_map(partial(wsc_trick_process, hf_toker=hf_tokenizer),\n",
     "                                  cache_file_names=\"tricked_{split}.arrow\")\n",
     "  cols={'prefix':TensorText,'suffix':TensorText,'cands':TensorText,'cand_lens':noop,'label':TensorCategory}\n",
-    "  glue_dls['wnli'] = HF_Datasets(glue_dsets['wnli'], hf_toker=hf_tokenizer, n_inp=4, \n",
+    "  glue_dls['wnli'] = HF_Datasets(glue_dsets['wnli'], hf_toker=hf_tokenizer, n_inp=4, test_with_y=True,\n",
     "                                 cols=cols).dataloaders(bs=32, cache_name=\"dl_tricked_{split}.json\")"
    ]
   },
@@ -718,17 +719,24 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "wnli\nSome weights of the model checkpoint at google/electra-large-discriminator were not used when initializing ElectraForPreTraining: [&#39;electra.embeddings_project.weight&#39;, &#39;electra.embeddings_project.bias&#39;]\n- This IS expected if you are initializing ElectraForPreTraining from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPretraining model).\n- This IS NOT expected if you are initializing ElectraForPreTraining from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n"
+     "output_type": "stream",
+     "text": [
+      "wnli\n",
+      "Some weights of the model checkpoint at google/electra-large-discriminator were not used when initializing ElectraForPreTraining: [&#39;electra.embeddings_project.weight&#39;, &#39;electra.embeddings_project.bias&#39;]\n",
+      "- This IS expected if you are initializing ElectraForPreTraining from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPretraining model).\n",
+      "- This IS NOT expected if you are initializing ElectraForPreTraining from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n"
+     ]
     },
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "<IPython.core.display.HTML object>",
-      "text/html": ""
+      "text/html": [],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -778,7 +786,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7-final"
+   "version": "3.10.11"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Hi there! Thank you so much for your work on this project. I was using your script to finetune ELECTRA on a smaller dataset and noticed that the `learner` was not reporting accuracy or validation loss. I took some time to look into it and figured out the issue on my end.

The first issue was that without the `test_with_y=True` parameter, I did not see the labels inside the examples of the validation data loader. So I have added this parameter.

Second, the implementation of `accuracy` in the FastAI API used in the project seems to be broken, it was throwing an error like ```AttributeError: 'bool' object has no attribute 'float'```, so I have added code to cast the two tensors. I'm not sure this is the best way to do this but it worked for me. 

Thanks again for your work